### PR TITLE
[iOS]Context menu (바뀐 API에 맞게 수정)

### DIFF
--- a/iOS/ToDoProject/ToDoProject/Controller/ModalCardSheetViewController.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/ModalCardSheetViewController.swift
@@ -27,13 +27,13 @@ class ModalCardSheetViewController: UIViewController {
     @IBAction func uploadCardButtonTapped(_ sender: Any) {
         guard let title = self.titleTextField.text else { return }
         guard let contents = self.contentsTextField.text else { return }
-        // 이 부분 API 수정 후 row 수정하기
-        let card = NewCardForm(colName: column, row: 2, title: title, contents: contents, writer: "Lena")
+        let card = NewCardForm(title: title, contents: contents)
         
         if originalCardId == nil{
-            dataManager.requestUpdateCard(card: card, requestMethod: RequestMethod.post)
+            print(self.column)
+            dataManager.requestUpdateCard(card: card, requestMethod: RequestMethod.post, column: self.column, cardId: nil)
         } else {
-            dataManager.requestUpdateCard(card: card, requestMethod: RequestMethod.put)
+            dataManager.requestUpdateCard(card: card, requestMethod: RequestMethod.put, column: self.column, cardId: originalCardId)
         }
         self.dismiss(animated: true, completion: nil)
     }

--- a/iOS/ToDoProject/ToDoProject/Controller/TableViewDelegate.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/TableViewDelegate.swift
@@ -10,18 +10,29 @@ import UIKit
 
 extension ToDoManagerViewController: UITableViewDelegate{
     
-    static let EditCardNotification = NSNotification.Name("EditCardNotification")
-
     func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        let configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
-            let moveToDone = UIAction(title: "move to done") { _ in
-                self.moveCardToDone(indexPath: indexPath, tableView: tableView) }
-            let edit = UIAction(title: "edit...") { _ in
-                self.editCard(indexPath: indexPath, tableView: tableView) }
-            let delete = UIAction(title: "delete", attributes: .destructive) { _ in
-                self.deleteCard(indexPath: indexPath, tableView: tableView) }
-            let menu = UIMenu(title: "", children: [moveToDone, edit, delete])
-            return menu
+        var configuration = UIContextMenuConfiguration()
+        if self.column == ColumnURLName.done{
+            configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+                let edit = UIAction(title: "edit...") { _ in
+                    self.editCard(indexPath: indexPath, tableView: tableView) }
+                let delete = UIAction(title: "delete", attributes: .destructive) { _ in
+                    self.deleteCard(indexPath: indexPath, tableView: tableView) }
+                let menu = UIMenu(title: "", children: [edit, delete])
+                return menu
+            }
+        } else {
+            configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+                let moveToDone = UIAction(title: "move to done") { _ in
+                    self.moveCardToDone(indexPath: indexPath, tableView: tableView) }
+                let edit = UIAction(title: "edit...") { _ in
+                    self.editCard(indexPath: indexPath, tableView: tableView) }
+                let delete = UIAction(title: "delete", attributes: .destructive) { _ in
+                    self.deleteCard(indexPath: indexPath, tableView: tableView) }
+                let menu = UIMenu(title: "", children: [moveToDone, edit, delete])
+                return menu
+            }
+
         }
         return configuration
     }
@@ -31,16 +42,21 @@ extension ToDoManagerViewController: UITableViewDelegate{
         guard let cardIdToDelete = cardToDelete?.id else { return }
         self.dataManager.cardsData?.responseData.cards.remove(at: indexPath.row)
         tableView.deleteRows(at: [indexPath], with: .fade)
-        let cardId = DeleteCardForm(id: cardIdToDelete)
-        self.dataManager.requestDeleteCard(cardId: cardId)
+        guard let columnId = self.dataManager.cardsData?.responseData.id else { return }
+        guard let cardId = self.dataManager.cardsData?.responseData.cards[indexPath.row].id else { return }
+        self.dataManager.requestDeleteCard(columnId: columnId, cardId: cardId)
     }
     
     private func moveCardToDone(indexPath: IndexPath, tableView: UITableView){
         let currentColumn = self.switchName(column: self.column)
-        guard let lastCardIndex = self.dataSource.dataManager.cardsData?.responseData.cards.count else { return }
-        let moveCard = MoveCardForm(originColName: currentColumn, originRow: indexPath.row+1, destinationColName: "Done", destinationRow: lastCardIndex+1)
-        self.dataManager.requestMoveCard(movingInfo: moveCard)
+        let doneColumnId = 3
+        let toLast = 0
+        let moveCard = MoveCardForm(destinationId: doneColumnId, destinationRow: 9)
+        guard let columnId = self.dataManager.cardsData?.responseData.id else { return }
+        guard let cardId = self.dataManager.cardsData?.responseData.cards[indexPath.row].id else { return }
+        self.dataManager.requestMoveCard(movingInfo: moveCard, originalColumnId: columnId, originalCardId: cardId, originalCardRow: indexPath.row)
     }
+    
     
     private func editCard(indexPath: IndexPath, tableView: UITableView){
         let cardSheet = ModalCardSheetViewController()

--- a/iOS/ToDoProject/ToDoProject/Controller/ToDoManagerViewController.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/ToDoManagerViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import MobileCoreServices
 
 class ToDoManagerViewController: UIViewController {
     
@@ -74,7 +75,6 @@ class ToDoManagerViewController: UIViewController {
         } else if addedCardColumn == currentColumn && requestMethod == RequestMethod.put {
             DispatchQueue.main.async {
                 self.dataSource.dataManager = self.dataManager
-                // API 에서 row 변경하면 바꾸기
                 let editedCard = Card(id: addedCardInfo.id, row: addedCardInfo.row-1, title: addedCardInfo.title, contents: addedCardInfo.contents, writer: addedCardInfo.writer, deleted: addedCardInfo.deleted, writtenTime: addedCardInfo.writtenTime)
                 self.dataSource.dataManager.cardsData?.responseData.cards[addedCardInfo.row-1] = editedCard
                 
@@ -86,16 +86,19 @@ class ToDoManagerViewController: UIViewController {
     @objc private func updateTableViewAfterMoving(notification: Notification) {
         guard let movingInfo = notification.userInfo?[NotificationUserInfoKey.movingInfo] as? MoveCardForm else { return }
         guard let movedCard = notification.userInfo?[NotificationUserInfoKey.movedCard] as? Card else { return }
+        guard let originalCard = notification.userInfo?[NotificationUserInfoKey.originalCardInfo] as? (String,Int) else { return }
         let currentColum = switchName(column: self.column)
         guard let cardsCount = self.dataSource.dataManager.cardsData?.responseData.cards.count else { return }
+        let originalCardColumn = originalCard.0
+            let originalCardRow = originalCard.1
         DispatchQueue.main.async {
-            if currentColum == movingInfo.originColName{
+            if currentColum == originalCardColumn {
                 self.cardsNumberLabel.text = " \(cardsCount-1) "
-                self.dataSource.dataManager.cardsData?.responseData.cards.remove(at: movingInfo.originRow-1)
+                self.dataSource.dataManager.cardsData?.responseData.cards.remove(at: originalCardRow-1)
             }
-            if currentColum ==  movingInfo.destinationColName {
+            if currentColum == self.dataManager.switchColumnName(column: movingInfo.destinationId) {
                 self.cardsNumberLabel.text = " \(cardsCount+1) "
-                self.dataSource.dataManager.cardsData?.responseData.cards.insert(movedCard, at: movingInfo.destinationRow-1)
+                self.dataSource.dataManager.cardsData?.responseData.cards.insert(movedCard, at: originalCardRow-1)
             }
             self.ToDoTableView.reloadData()
         }
@@ -121,4 +124,4 @@ class ToDoManagerViewController: UIViewController {
             return ""
         }
     }
-}
+}                                   

--- a/iOS/ToDoProject/ToDoProject/Model/ToDoTableViewDataSource.swift
+++ b/iOS/ToDoProject/ToDoProject/Model/ToDoTableViewDataSource.swift
@@ -34,8 +34,10 @@ class ToDoTableViewDataSource: NSObject, UITableViewDataSource {
             guard let cardIdToDelete = cardToDelete?.id else { return }
            dataManager.cardsData?.responseData.cards.remove(at: indexPath.row)
            tableView.deleteRows(at: [indexPath], with: .fade)
-            let cardId = DeleteCardForm(id: cardIdToDelete)
-            dataManager.requestDeleteCard(cardId: cardId)
+            guard let columnId = self.dataManager.cardsData?.responseData.id else { return }
+            guard let cardId = self.dataManager.cardsData?.responseData.cards[indexPath.row].id else { return }
+            dataManager.requestDeleteCard(columnId: columnId, cardId: cardId)
         }
     }
 }
+

--- a/iOS/ToDoProject/ToDoProject/Utility.swift
+++ b/iOS/ToDoProject/ToDoProject/Utility.swift
@@ -41,10 +41,13 @@ enum NotificationUserInfoKey {
     static let requestMethod = "requestMethod"
     static let movingInfo = "movingInfo"
     static let movedCard = "movedCard"
+    static let originalCardInfo = "originalCardInfo"
 }
 
 enum RequestMethod {
-    static let post = "Post"
-    static let put = "Put" // edit card
-    static let delete = "Delete" // delete card
+    static let get = "GET"
+    static let post = "POST"
+    static let put = "PUT" // edit card
+    static let patch = "PATCH"
+    static let delete = "DELETE" // delete card
 }

--- a/iOS/ToDoProject/ToDoProject/View/ToDoCardInfo.swift
+++ b/iOS/ToDoProject/ToDoProject/View/ToDoCardInfo.swift
@@ -30,12 +30,15 @@ struct Card: Codable {
     let writtenTime: String
 }
 
-struct NewCardForm: Codable{
+struct AddCardForm: Codable {
     let colName: String
-    let row: Int
     let title: String
     let contents: String
-    let writer: String
+}
+
+struct NewCardForm: Codable{
+    let title: String
+    let contents: String
 }
 
 struct ResponseDataForm: Codable {
@@ -43,13 +46,7 @@ struct ResponseDataForm: Codable {
     let responseData: Card
 }
 
-struct DeleteCardForm: Codable {
-    let id: Int
-}
-
 struct MoveCardForm: Codable {
-    let originColName: String
-    let originRow: Int
-    let destinationColName: String
+    let destinationId: Int
     let destinationRow: Int
 }


### PR DESCRIPTION
### 추가 구현한 부분:
*  카드를 깊게 누르면 나오는 Context Menu 구현했습니다.
 1. Context Menu에 있는 Delete 기능
 2. Context Menu에 있는 Edit 기능
 3. Context Menu에 있는 Move To Done 기능
* 바뀐 API에 맞게 수정
 1. http header에 토큰을 담아 보냄
 2. url  변경
 3. httpBody에 담아 보낼 Json 구조 변경

### 고민한 부분
1. 카드 추가 때와 마찬가지로 추가된 카드가 반영된 데이터를 서버에 재요청해서 tableView를 reload하려고 했으나 잘 안되서 삭제, 수정, 이동 요청이 끝난 후 노티피케이션을 보내 DataManager의 DataSource가 갖고있는 CardList에 반영하여 보여지도록 하는 방식으로 구현했습니다.
2. 카드 수정을 할 때, request method외에 추가와 요청 방식이 동일하다고 생각해서 수정을 위한 메소드를 따로 만들었다가 추가 메소드를 변형해서 재사용했습니다.
3. 이전에는 Column Name을 주로 사용했는데 Column Id를 사용하는 방법으로 API가 변경되어서 이를 바꾸는 switch문을 썼는데 좋은 방법인지 모르겠습니다. 🧐
4. 상위 클래스에서 하위 클래스의 프로퍼티를 직접 바꾸고 있는데 이 부분도 좋은 방법인지 모르겠습니다. 😢