### PR TITLE
Drag and Drop 및 기타 추가 기능

### DIFF
--- a/iOS/ToDoProject/ToDoProject.xcodeproj/project.pbxproj
+++ b/iOS/ToDoProject/ToDoProject.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		6A02539224476BB500477ABE /* TableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A02539124476BB500477ABE /* TableViewDelegate.swift */; };
 		6A0253952447710E00477ABE /* ModalCardSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0253932447710E00477ABE /* ModalCardSheetViewController.swift */; };
 		6A0253962447710E00477ABE /* ModalCardSheetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6A0253942447710E00477ABE /* ModalCardSheetViewController.xib */; };
+		6A02539A2448A61000477ABE /* TableVIewDragAndDropDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0253992448A61000477ABE /* TableVIewDragAndDropDelegate.swift */; };
+		6A02539D2448EE5600477ABE /* PoPOverMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A02539B2448EE5600477ABE /* PoPOverMenuViewController.swift */; };
+		6A02539E2448EE5600477ABE /* PoPOverMenuViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6A02539C2448EE5600477ABE /* PoPOverMenuViewController.xib */; };
 		6A21A9A824402D12009B2983 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A21A9A724402D12009B2983 /* Utility.swift */; };
 		6A74866A243AEFB200D89B3D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A748669243AEFB200D89B3D /* AppDelegate.swift */; };
 		6A74866C243AEFB200D89B3D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A74866B243AEFB200D89B3D /* SceneDelegate.swift */; };
@@ -40,6 +43,9 @@
 		6A02539124476BB500477ABE /* TableViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewDelegate.swift; sourceTree = "<group>"; };
 		6A0253932447710E00477ABE /* ModalCardSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalCardSheetViewController.swift; sourceTree = "<group>"; };
 		6A0253942447710E00477ABE /* ModalCardSheetViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ModalCardSheetViewController.xib; sourceTree = "<group>"; };
+		6A0253992448A61000477ABE /* TableVIewDragAndDropDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableVIewDragAndDropDelegate.swift; sourceTree = "<group>"; };
+		6A02539B2448EE5600477ABE /* PoPOverMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoPOverMenuViewController.swift; sourceTree = "<group>"; };
+		6A02539C2448EE5600477ABE /* PoPOverMenuViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PoPOverMenuViewController.xib; sourceTree = "<group>"; };
 		6A21A9A724402D12009B2983 /* Utility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utility.swift; sourceTree = "<group>"; };
 		6A748666243AEFB200D89B3D /* ToDoProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDoProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A748669243AEFB200D89B3D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -149,6 +155,9 @@
 				6A02539124476BB500477ABE /* TableViewDelegate.swift */,
 				6A0253932447710E00477ABE /* ModalCardSheetViewController.swift */,
 				6A0253942447710E00477ABE /* ModalCardSheetViewController.xib */,
+				6A0253992448A61000477ABE /* TableVIewDragAndDropDelegate.swift */,
+				6A02539B2448EE5600477ABE /* PoPOverMenuViewController.swift */,
+				6A02539C2448EE5600477ABE /* PoPOverMenuViewController.xib */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -239,6 +248,7 @@
 				6A748671243AEFB200D89B3D /* Main.storyboard in Resources */,
 				6A0253962447710E00477ABE /* ModalCardSheetViewController.xib in Resources */,
 				6A820547243F32C40057780D /* ToDoTableViewCell.xib in Resources */,
+				6A02539E2448EE5600477ABE /* PoPOverMenuViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -257,9 +267,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A21A9A824402D12009B2983 /* Utility.swift in Sources */,
+				6A02539A2448A61000477ABE /* TableVIewDragAndDropDelegate.swift in Sources */,
 				6A74868F243B48BD00D89B3D /* ToDoManagerViewController.swift in Sources */,
 				6A0253952447710E00477ABE /* ModalCardSheetViewController.swift in Sources */,
 				6A820540243F0D340057780D /* DataManager.swift in Sources */,
+				6A02539D2448EE5600477ABE /* PoPOverMenuViewController.swift in Sources */,
 				6A74866E243AEFB200D89B3D /* MasterViewController.swift in Sources */,
 				6A820546243F32C40057780D /* ToDoTableViewCell.swift in Sources */,
 				6A74866A243AEFB200D89B3D /* AppDelegate.swift in Sources */,

--- a/iOS/ToDoProject/ToDoProject/Base.lproj/Main.storyboard
+++ b/iOS/ToDoProject/ToDoProject/Base.lproj/Main.storyboard
@@ -57,12 +57,16 @@
                     <navigationItem key="navigationItem" id="ZcI-Jg-frL">
                         <barButtonItem key="rightBarButtonItem" title="Menu" id="PIB-3H-dWN">
                             <color key="tintColor" name="violetsAreBlue"/>
+                            <connections>
+                                <action selector="MenuButtonTapped:" destination="BYZ-38-t0r" id="bhD-7O-2ly"/>
+                            </connections>
                         </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="doneListContainerView" destination="ivY-Yd-mZP" id="baj-xJ-zVt"/>
                         <outlet property="inProgressListContainerView" destination="oB1-uL-wfF" id="1mc-hi-6uy"/>
+                        <outlet property="menuButton" destination="PIB-3H-dWN" id="Qvr-uP-ipF"/>
                         <outlet property="toDoListContainerView" destination="ATt-Dq-VT9" id="Wax-Sb-nHy"/>
                     </connections>
                 </viewController>

--- a/iOS/ToDoProject/ToDoProject/Controller/MasterViewController.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/MasterViewController.swift
@@ -8,17 +8,101 @@
 
 import UIKit
 
-class MasterViewController: UIViewController {
-
+class MasterViewController: UIViewController, UIPopoverPresentationControllerDelegate {
+    
     @IBOutlet weak var toDoListContainerView: UIView!
     @IBOutlet weak var inProgressListContainerView: UIView!
     @IBOutlet weak var doneListContainerView: UIView!
+    @IBOutlet weak var menuButton: UIBarButtonItem!
+    var popMenuVC = PoPOverMenuViewController()
     private var toDoListVC: ToDoManagerViewController!
     private var inProgressListVC: ToDoManagerViewController!
     private var doneListVC: ToDoManagerViewController!
+    var startToMoveCard: Card?
+    var sourceColumnId: Int?
+    var sourceCardIndexRow: Int?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupNotification()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: ToDoManagerViewController.ToDoCardStartToMoveNotification, object: nil)
+    }
+    
+    private func setupNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(readyToChangeSourceTable), name: ToDoManagerViewController.ToDoCardStartToMoveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(changeSourceTable), name: ToDoManagerViewController.ToDoCardDoneToMoveNotification, object: nil)
+        
+    }
+    
+    func rightItemClick()
+    {
+        self.popMenuVC.modalPresentationStyle = .popover
+        self.popMenuVC.popoverPresentationController?.barButtonItem = self.navigationItem.rightBarButtonItem
+        self.popMenuVC.popoverPresentationController?.permittedArrowDirections = .unknown
+        self.popMenuVC.popoverPresentationController?.delegate = self
+        self.present(self.popMenuVC, animated: true, completion: nil)
+        
+    }
+    
+    @objc func readyToChangeSourceTable(_ notification: Notification){
+        guard let startToMoveCard = notification.userInfo?[NotificationUserInfoKey.startToMoveCard] as? Card else { return }
+        guard let sourceColumnId = notification.userInfo?[NotificationUserInfoKey.sourceColumnId] as? Int else { return }
+        guard let sourceCardIndexRow = notification.userInfo?[NotificationUserInfoKey.sourceCardIndexRow] as? Int else { return }
+        self.startToMoveCard = startToMoveCard
+        self.sourceColumnId = sourceColumnId
+        self.sourceCardIndexRow = sourceCardIndexRow
+    }
+    
+    @objc func changeSourceTable(_ notification: Notification){
+        let dataManager =  DataManager()
+        let toDoId = dataManager.switchURLColumnId(column: self.toDoListVC.column)
+        
+        let inProgressId = dataManager.switchURLColumnId(column: self.inProgressListVC.column)
+        let doneId = dataManager.switchURLColumnId(column: self.doneListVC.column)
+        
+        if self.sourceColumnId == toDoId {
+            DispatchQueue.main.async {
+                self.toDoListVC.ToDoTableView.reloadData()
+            }
+        } else if self.sourceColumnId == inProgressId {
+            DispatchQueue.main.async {
+                self.inProgressListVC.ToDoTableView.reloadData()
+            }
+            
+        }else{
+            DispatchQueue.main.async {
+                self.doneListVC.ToDoTableView.reloadData()
+            }
+        }
+    }
+    
+    @objc func tableDidSelected(_ notification: Notification)
+    {
+        var indexpath: IndexPath? = (notification.object as? IndexPath)
+        switch indexpath?.row {
+        case 0: toDoListVC.dataSource.dataManager.cardsData?.responseData.cards.removeAll()// To Do Clear
+        case 1: inProgressListVC.dataSource.dataManager.cardsData?.responseData.cards.removeAll()
+        case 2: doneListVC.dataSource.dataManager.cardsData?.responseData.cards.removeAll()
+        default:
+            print("nothing")
+        }
+        self.toDoListVC.ToDoTableView.reloadData()
+        self.inProgressListVC.ToDoTableView.reloadData()
+        self.doneListVC.ToDoTableView.reloadData()
+        self.popMenuVC.dismiss(animated: true, completion: nil)
+    }
+    
+    func popoverPresentationControllerShouldDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) -> Bool
+    {
+        return true
+    }
+    
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle
+    {
+        return UIModalPresentationStyle.none
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -33,7 +117,7 @@ class MasterViewController: UIViewController {
             inProgressVC.headerTitle = Column.inProgressColumn
             inProgressListVC = inProgressVC
             inProgressVC.column = ColumnURLName.inProgress
-
+            
         }
         if segue.identifier == Column.doneColumn{
             let doneVC = segue.destination as! ToDoManagerViewController
@@ -41,6 +125,14 @@ class MasterViewController: UIViewController {
             doneListVC = doneVC
             doneVC.column = ColumnURLName.done
         }
+    }
+    
+    @IBAction func MenuButtonTapped(_ sender: UIBarButtonItem) {
+        let array = ["Clear To Do Cards","Clear In Progress Cards","Clear Done Cards"]
+        popMenuVC.arrayListPopover = array
+        NotificationCenter.default.addObserver(self, selector: #selector(self.tableDidSelected), name: NSNotification.Name(rawValue: "click"), object: nil)
+        rightItemClick()
+        
     }
 }
 

--- a/iOS/ToDoProject/ToDoProject/Controller/ModalCardSheetViewController.xib
+++ b/iOS/ToDoProject/ToDoProject/Controller/ModalCardSheetViewController.xib
@@ -45,15 +45,20 @@
                         <action selector="uploadCardButtonTapped:" destination="-1" eventType="touchUpInside" id="fkH-cv-J2h"/>
                     </connections>
                 </button>
-                <textView clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.20000000298023224" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Lec-jW-EtY">
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lec-jW-EtY">
                     <rect key="frame" x="20" y="172" width="374" height="463"/>
-                    <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                             <integer key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                            <color key="value" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="TextView.textColor">
+                            <color key="value" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </textView>

--- a/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.swift
@@ -1,0 +1,30 @@
+//
+//  PoPOverMenuViewController.swift
+//  ToDoProject
+//
+//  Created by Keunna Lee on 2020/04/17.
+//  Copyright © 2020 dev-Lena. All rights reserved.
+//
+
+import UIKit
+
+class PoPOverMenuViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.swift
@@ -8,23 +8,57 @@
 
 import UIKit
 
-class PoPOverMenuViewController: UIViewController {
-
-    override func viewDidLoad() {
+class PoPOverMenuViewController: UIViewController,UITableViewDelegate,UITableViewDataSource
+{
+    var arrayListPopover : [String] = []
+    private let tableView = UITableView()
+    
+    override func viewDidLoad()
+    {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        self.view.addSubview(tableView)
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.isScrollEnabled = true
+        tableView.backgroundColor = UIColor.clear
+        tableView.bounces = false
+        configureSizeForChildView(forTableView: 300)
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    override func didReceiveMemoryWarning()
+    {
+        super.didReceiveMemoryWarning()
     }
-    */
-
+    
+    func configureSizeForChildView(forTableView width : CGFloat)
+    {
+        var tempSize = self.presentingViewController?.view.bounds.size
+        tempSize?.width = width
+        let size = tableView.sizeThatFits(tempSize!)
+        self.preferredContentSize = size
+        self.view.systemLayoutSizeFitting(tableView.frame.size)
+        self.tableView.frame = self.view.frame
+    }
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int
+    {
+        return arrayListPopover.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell
+    {
+        let cellIdentifer: String = "cell"
+        var cell: UITableViewCell? = tableView.dequeueReusableCell(withIdentifier: cellIdentifer)
+        if cell == nil{
+            cell = UITableViewCell(style: .default, reuseIdentifier: cellIdentifer)
+        }
+        cell?.backgroundColor = UIColor.clear
+        cell?.textLabel?.text = "\(arrayListPopover[indexPath.row])"
+        return cell!
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath)
+    {
+        NotificationCenter.default.post(name:  NSNotification.Name(rawValue: "click"), object: indexPath)
+    }
+    
 }

--- a/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.xib
+++ b/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.xib
@@ -1,22 +1,24 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PoPOverMenuViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PoPOverMenuViewController" customModule="ToDoProject" customModuleProvider="target">
             <connections>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="139" y="145"/>
         </view>
     </objects>
 </document>

--- a/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.xib
+++ b/iOS/ToDoProject/ToDoProject/Controller/PoPOverMenuViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PoPOverMenuViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/iOS/ToDoProject/ToDoProject/Controller/TableVIewDragAndDropDelegate.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/TableVIewDragAndDropDelegate.swift
@@ -1,0 +1,115 @@
+//
+//  TableVIewDragAndDropDelegate.swift
+//  ToDoProject
+//
+//  Created by Keunna Lee on 2020/04/16.
+//  Copyright © 2020 dev-Lena. All rights reserved.
+//
+
+import UIKit
+import MobileCoreServices
+
+extension ToDoManagerViewController: UITableViewDragDelegate{
+    func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        let card = self.dataManager.cardsData?.responseData.cards[indexPath.row]
+        
+        guard let dragedCard = self.dataManager.cardsData?.responseData.cards[indexPath.row] else {
+            return []
+        }
+        
+        let itemProvider = NSItemProvider()
+        let dragItem = UIDragItem(itemProvider: itemProvider)
+        itemProvider.registerDataRepresentation(forTypeIdentifier: kUTTypePlainText as String, visibility: .all) { completion in
+            completion(card as? Data? ?? nil, nil)
+            return nil
+        }
+        let cardToDrag = DraggedCard(draggedCardInfo: dragedCard, draggedCardIndex: indexPath.row, draggedCardColumnId: self.dataManager.switchURLColumnId(column: self.column))
+        dragItem.localObject = cardToDrag
+        self.sendToDoCardStartToMoveNotification(card: dragedCard, sourceColumnId: self.dataManager.switchURLColumnId(column: self.column), sourceCardIndexRow: indexPath.row)
+        return [dragItem]
+    }
+}
+
+extension ToDoManagerViewController: UITableViewDropDelegate {
+    func tableView(_ tableView: UITableView, canHandle session: UIDropSession) -> Bool {
+        return self.dataSource.canHandle(session)
+    }
+    
+    func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
+        if tableView.hasActiveDrag {
+            if session.items.count > 1 {
+                return UITableViewDropProposal(operation: .cancel)
+            } else {
+                return UITableViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
+            }
+        } else {
+            return UITableViewDropProposal(operation: .copy, intent: .insertAtDestinationIndexPath)
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, performDropWith coordinator: UITableViewDropCoordinator) {
+        let destinationIndexPath: IndexPath
+        
+        if let indexPath = coordinator.destinationIndexPath {
+            destinationIndexPath = indexPath
+        } else {
+            let row = tableView.numberOfRows(inSection: 0)
+            destinationIndexPath = IndexPath(row: row, section: 0)
+        }
+        
+        for item in coordinator.items {
+            if let sourceIndexPath = item.sourceIndexPath {
+                // Between Same Table
+                var indexPaths = [IndexPath]()
+                indexPaths.append(destinationIndexPath)
+                var originIndexPaths = [IndexPath]()
+                originIndexPaths.append(sourceIndexPath)
+                tableView.beginUpdates()
+                self.dataSource.moveItem(at: sourceIndexPath.row, to: destinationIndexPath.row)
+                DispatchQueue.main.async {
+                    self.ToDoTableView.reloadData()
+                }
+                tableView.endUpdates()
+                let columnId = self.dataManager.switchURLColumnId(column: self.column)
+                let moveCard = MoveCardForm(destinationId: columnId, destinationRow: destinationIndexPath.row)
+                self.dataManager.requestMoveCard(movingInfo: moveCard, originalColumnId: columnId, originalCardId: columnId, originalCardRow: sourceIndexPath.row)
+                
+            } else if let dragObject = item.dragItem.localObject as? DraggedCard {
+                // Between Different Table
+                let card = item.dragItem.localObject as? DraggedCard
+                guard let movingCard = card?.draggedCardInfo else {return}
+                self.dataSource.addItem(movingCard, at: destinationIndexPath.row)
+                
+                let currentColumnId = self.dataManager.switchURLColumnId(column: self.column)
+                
+                let columnId = self.dataManager.switchURLColumnId(column: self.column)
+                let moveCard = MoveCardForm(destinationId: currentColumnId, destinationRow: destinationIndexPath.row)
+                guard let sourceColumnId = card?.draggedCardColumnId else {return}
+                guard let sourceCardId = card?.draggedCardInfo.id else {
+                    return
+                }
+                guard let sourceCardIndex = card?.draggedCardIndex else {
+                    return
+                }
+                self.dataManager.requestMoveCard(movingInfo: moveCard, originalColumnId: sourceColumnId, originalCardId: sourceCardId, originalCardRow: sourceCardIndex+1)
+                tableView.endUpdates()
+
+                if currentColumnId == moveCard.destinationId {
+                    self.dataSource.dataManager.cardsData?.responseData.cards.removeLast()
+                }
+                DispatchQueue.main.async {
+                    self.ToDoTableView.reloadData()
+                }
+                self.sendFinishToMoveNotification()
+                
+            }
+        }
+    }
+    
+    @objc func sendDragedCard(notification: Notification) {
+        guard let card = notification.userInfo?[NotificationUserInfoKey.dragAndDropCard] as? Card else { return }
+        guard let cardIndex = notification.userInfo?[NotificationUserInfoKey.dragedCardIndex] as? Int else { return }
+        self.dragedCard = card
+        self.dragedCardIndex = cardIndex
+    }
+}

--- a/iOS/ToDoProject/ToDoProject/Controller/TableViewDelegate.swift
+++ b/iOS/ToDoProject/ToDoProject/Controller/TableViewDelegate.swift
@@ -14,22 +14,49 @@ extension ToDoManagerViewController: UITableViewDelegate{
         var configuration = UIContextMenuConfiguration()
         if self.column == ColumnURLName.done{
             configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
-                let edit = UIAction(title: "edit...") { _ in
+                let moveToToDo = UIAction(title: "move to To Do", image: UIImage(systemName: SystemImageName.arrowToLeftTwice)) { _ in
+                    let toDoColumnId = 1
+                    self.moveCard(indexPath: indexPath, tableView: tableView, columnId: toDoColumnId) }
+                let moveToInProgress = UIAction(title: "move to In Progress", image: UIImage(systemName: SystemImageName.arrowToLeft)) { _ in
+                    let doneColumnId = 2
+                    self.moveCard(indexPath: indexPath, tableView: tableView, columnId: doneColumnId) }
+
+                let edit = UIAction(title: "edit", image: UIImage(systemName: SystemImageName.pencil)) { _ in
                     self.editCard(indexPath: indexPath, tableView: tableView) }
-                let delete = UIAction(title: "delete", attributes: .destructive) { _ in
+                let delete = UIAction(title: "delete", image: UIImage(systemName: SystemImageName.trashBin), attributes: .destructive) { _ in
                     self.deleteCard(indexPath: indexPath, tableView: tableView) }
-                let menu = UIMenu(title: "", children: [edit, delete])
+                let menu = UIMenu(title: "", children: [moveToToDo, moveToInProgress, edit, delete])
+                return menu
+            }            
+        } else if self.column == ColumnURLName.inProgress{
+            configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+                let moveToToDo = UIAction(title: "move to To Do", image: UIImage(systemName: SystemImageName.arrowToLeft)) { _ in
+                    let toDoColumnId = 1
+                    self.moveCard(indexPath: indexPath, tableView: tableView, columnId: toDoColumnId) }
+                let moveToDone = UIAction(title: "move to Done", image: UIImage(systemName: SystemImageName.arrowToRight)) { _ in
+                    let doneColumnId = 3
+                    self.moveCard(indexPath: indexPath, tableView: tableView, columnId: doneColumnId) }
+                let edit = UIAction(title: "edit", image: UIImage(systemName: SystemImageName.pencil)) { _ in
+                    self.editCard(indexPath: indexPath, tableView: tableView) }
+                let delete = UIAction(title: "delete", image: UIImage(systemName: SystemImageName.trashBin), attributes: .destructive) { _ in
+                    self.deleteCard(indexPath: indexPath, tableView: tableView) }
+                let menu = UIMenu(title: "", children: [moveToToDo, moveToDone, edit, delete])
                 return menu
             }
+
         } else {
             configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
-                let moveToDone = UIAction(title: "move to done") { _ in
-                    self.moveCardToDone(indexPath: indexPath, tableView: tableView) }
-                let edit = UIAction(title: "edit...") { _ in
+                let moveToInProgress = UIAction(title: "move to In Progress", image: UIImage(systemName: SystemImageName.arrowToRight)) { _ in
+                    let doneColumnId = 2
+                    self.moveCard(indexPath: indexPath, tableView: tableView, columnId: doneColumnId) }
+                let moveToDone = UIAction(title: "move to Done", image: UIImage(systemName: SystemImageName.arrowToRight)) { _ in
+                    let doneColumnId = 3
+                    self.moveCard(indexPath: indexPath, tableView: tableView, columnId: doneColumnId) }
+                let edit = UIAction(title: "edit", image: UIImage(systemName: SystemImageName.pencil)) { _ in
                     self.editCard(indexPath: indexPath, tableView: tableView) }
-                let delete = UIAction(title: "delete", attributes: .destructive) { _ in
+                let delete = UIAction(title: "delete", image: UIImage(systemName: SystemImageName.trashBin), attributes: .destructive) { _ in
                     self.deleteCard(indexPath: indexPath, tableView: tableView) }
-                let menu = UIMenu(title: "", children: [moveToDone, edit, delete])
+                let menu = UIMenu(title: "", children: [moveToInProgress, moveToDone, edit, delete])
                 return menu
             }
 
@@ -38,25 +65,22 @@ extension ToDoManagerViewController: UITableViewDelegate{
     }
     
     private func deleteCard(indexPath: IndexPath, tableView: UITableView){
-        let cardToDelete = self.dataManager.cardsData?.responseData.cards[indexPath.row]
-        guard let cardIdToDelete = cardToDelete?.id else { return }
-        self.dataManager.cardsData?.responseData.cards.remove(at: indexPath.row)
+        let cardToDelete = self.dataSource.dataManager.cardsData?.responseData.cards[indexPath.row]
+        guard let cardId = cardToDelete?.id else { return }
+        let columnId = self.dataManager.switchURLColumnId(column: self.column)
+        self.dataSource.dataManager.cardsData?.responseData.cards.remove(at: indexPath.row)
         tableView.deleteRows(at: [indexPath], with: .fade)
-        guard let columnId = self.dataManager.cardsData?.responseData.id else { return }
-        guard let cardId = self.dataManager.cardsData?.responseData.cards[indexPath.row].id else { return }
-        self.dataManager.requestDeleteCard(columnId: columnId, cardId: cardId)
+        self.dataSource.dataManager.requestDeleteCard(columnId: columnId, cardId: cardId)
     }
     
-    private func moveCardToDone(indexPath: IndexPath, tableView: UITableView){
+    private func moveCard(indexPath: IndexPath, tableView: UITableView, columnId: Int){
         let currentColumn = self.switchName(column: self.column)
-        let doneColumnId = 3
-        let toLast = 0
-        let moveCard = MoveCardForm(destinationId: doneColumnId, destinationRow: 9)
+        let toLast = 99 // 백엔드와 상의해서 99로 보내면 Destination Column에 마지막에 붙음
+        let moveCard = MoveCardForm(destinationId: columnId, destinationRow: toLast)
         guard let columnId = self.dataManager.cardsData?.responseData.id else { return }
         guard let cardId = self.dataManager.cardsData?.responseData.cards[indexPath.row].id else { return }
         self.dataManager.requestMoveCard(movingInfo: moveCard, originalColumnId: columnId, originalCardId: cardId, originalCardRow: indexPath.row)
     }
-    
     
     private func editCard(indexPath: IndexPath, tableView: UITableView){
         let cardSheet = ModalCardSheetViewController()
@@ -74,4 +98,14 @@ extension ToDoManagerViewController: UITableViewDelegate{
         cardSheet.contentsTextField.text = originalCard?.contents
         self.present(cardSheet, animated: true, completion: nil)
     }
+    
+    // Drag & Drop
+    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+    
+    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        self.dataSource.moveItem(at: sourceIndexPath.row, to: destinationIndexPath.row)
+    }
+
 }

--- a/iOS/ToDoProject/ToDoProject/Utility.swift
+++ b/iOS/ToDoProject/ToDoProject/Utility.swift
@@ -17,6 +17,12 @@ enum KeyColorName{
 enum SystemImageName{
     static let circle = "circle.fill"
     static let plus = "plus"
+    static let pencil = "square.and.pencil"
+    static let trashBin = "trash.fill"
+    static let arrowToRight = "arrowshape.turn.up.right.fill"
+    static let arrowToLeft = "arrowshape.turn.up.left.fill"
+    static let arrowToLeftTwice = "arrowshape.turn.up.left.2.fill"
+    static let arrowToRightTwice = "arrowshape.turn.up.right.2.fill"
 }
 
 enum Column {
@@ -42,6 +48,14 @@ enum NotificationUserInfoKey {
     static let movingInfo = "movingInfo"
     static let movedCard = "movedCard"
     static let originalCardInfo = "originalCardInfo"
+    static let dragAndDropCard = "dragAndDropCard"
+    static let dragedCardIndex = "dragedCardIndex"
+    static let startToMoveCard = "startToMoveCard"
+    static let doneToMoveCard = "doneToMoveCard"
+    static let sourceColumnId = "sourceColumnId"
+    static let sourceCardIndexRow = "sourceCardIndexRow"
+    static let destinationColumnId = "destinationColumnId"
+    static let destinationCardIndexRow = "destinationCardIndexRow"
 }
 
 enum RequestMethod {

--- a/iOS/ToDoProject/ToDoProject/View/DataManager.swift
+++ b/iOS/ToDoProject/ToDoProject/View/DataManager.swift
@@ -46,7 +46,7 @@ class DataManager {
         
         task.resume()
     }
-
+    
     // Add Card and Edit Card
     func requestUpdateCard(card: NewCardForm, requestMethod: String, column: String, cardId: Int?) {
         let columnId = switchColumnId(column: column)
@@ -92,25 +92,25 @@ class DataManager {
     func requestDeleteCard(columnId: Int,cardId: Int) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-            let url = URL(string: "http://15.164.78.121:8080/api/columns/\(columnId)/cards/\(cardId)")
-            var request = URLRequest(url: url!)
-            request.httpMethod = RequestMethod.delete
-            request.addValue(self.headerUserId, forHTTPHeaderField: "Authorization")
+        let url = URL(string: "http://15.164.78.121:8080/api/columns/\(columnId)/cards/\(cardId)")
+        var request = URLRequest(url: url!)
+        request.httpMethod = RequestMethod.delete
+        request.addValue(self.headerUserId, forHTTPHeaderField: "Authorization")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-
-            let task = URLSession.shared.dataTask(with: request){ (data, response, error) in
-                guard let data = data, error == nil else { print("error=\(error)")
-                    return }
-                if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode != 200 {
-                    print("statusCode should be 200, but is \(httpStatus.statusCode)")
-                    print("response = \(response)")
-                } else {
-                    print("statusCode is 200, Success")
-                    self.sendNotification()
-                }
+        
+        let task = URLSession.shared.dataTask(with: request){ (data, response, error) in
+            guard let data = data, error == nil else { print("error=\(error)")
+                return }
+            if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode != 200 {
+                print("statusCode should be 200, but is \(httpStatus.statusCode)")
+                print("response = \(response)")
+            } else {
+                print("statusCode is 200, Success")
+                self.sendNotification()
             }
-            task.resume()
         }
+        task.resume()
+    }
     
     
     func requestMoveCard(movingInfo: MoveCardForm, originalColumnId: Int, originalCardId: Int, originalCardRow: Int){
@@ -162,6 +162,16 @@ class DataManager {
         case Column.toDoColumn : return 1
         case Column.inProgressColumn : return 2
         case Column.doneColumn : return 3
+        default:
+            return 1
+        }
+    }
+    
+    func switchURLColumnId(column: String) -> Int {
+        switch column {
+        case ColumnURLName.toDo : return 1
+        case ColumnURLName.inProgress : return 2
+        case ColumnURLName.done : return 3
         default:
             return 1
         }

--- a/iOS/ToDoProject/ToDoProject/View/ToDoCardInfo.swift
+++ b/iOS/ToDoProject/ToDoProject/View/ToDoCardInfo.swift
@@ -50,3 +50,17 @@ struct MoveCardForm: Codable {
     let destinationId: Int
     let destinationRow: Int
 }
+
+struct DraggedCard {
+    let draggedCardInfo: Card
+    let draggedCardIndex: Int
+    let draggedCardColumnId: Int
+}
+
+struct CardToDropInfo {
+    let sourceColumnId: Int
+    let sourceCardRow: Int
+    let destinationColumnId: Int
+    let destinationCardRow: Int
+    let cardToDrop: Card
+}


### PR DESCRIPTION
* 추가 구현 한 부분
1. 오른쪽 상단에 메뉴 버튼을 누르면 각 Column의 카드를 모두 지울 수 있는 PopOver Meue를 추가했습니다
(예 - Clear To Do Card 선택시 To Do Column에 있는 카드가 모두 삭제됩니다)
2. 카드를 꾹 누르면 나오는 context menu에서 현재 카드가 속해있는 Column을 제외한 다른 Column으로 이동할 수 있는 move 기능을 추가했습니다.
3. Drag and Drop
  3.1 같은 테이블 내에서 Drag and Drop으로 카드를 이동할 수 있습니다.
  3.2 테이블 간 Drag and Drop 이동은 현재 이동이 되기는 하지만 Destination Column에 카드 하나가 더 추가되는 문제가 있어 수정이 필요합니다. 
4. API 변경(url, JWT, http body) 후 반영하여 수정했습니다.

p.s. Drag and Drop을 이용한 테이블 간 카드 이동은 수정이 필요합니다! 